### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,6 +9,8 @@ on:
 
 # no need to bother caching bun deps
 # https://github.com/oven-sh/setup-bun/issues/14#issuecomment-1714116221
+permissions:
+  contents: read
 jobs:
   check:
     runs-on: ubuntu-latest

--- a/.github/workflows/semantic-pr.yml
+++ b/.github/workflows/semantic-pr.yml
@@ -7,6 +7,9 @@ on:
 
 jobs:
   lint-title:
+    permissions:
+      contents: read
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - name: Check PR title against Conventional Commit format


### PR DESCRIPTION
Potential fix for [https://github.com/sripwoud/web-app-template/security/code-scanning/2](https://github.com/sripwoud/web-app-template/security/code-scanning/2)

To fix the problem, add a `permissions` block with the least privilege required to the workflow or job. The best approach is to add this at the job level (`lint-title`), just before `runs-on: ubuntu-latest`. For `amannn/action-semantic-pull-request@v5`, according to its documentation, the required permission is `pull-requests: write` (for posting comments/checks) and possibly `contents: read`. The recommended minimal permissions block is:

```yaml
permissions:
  contents: read
  pull-requests: write
```

This change should be made to lines following the job name (before `runs-on`). No imports or other code changes are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
